### PR TITLE
Added support for XDebug

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -20,10 +20,12 @@ RUN \
     && pip install $INSTALL_PIP \
     && npm install $INSTALL_NPM -g \
     && docker-php-ext-install bcmath \
+    && pecl install xdebug \
+    && docker-php-ext-enable xdebug \
     && mkdir /root/.ssh \
     && touch /root/.ssh/known_hosts \
     && ssh-keyscan bitbucket.org >> /root/.ssh/known_hosts \
-    && ssh-keyscan github.com >> /root/.ssh/known_hosts \    
+    && ssh-keyscan github.com >> /root/.ssh/known_hosts \
     && curl -O https://raw.githubusercontent.com/DealerDirect/php-qa-tools/master/bin/install.sh \
     && bash install.sh \
     && rm -f install.sh \

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -20,6 +20,8 @@ RUN \
     && pip install $INSTALL_PIP \
     && npm install $INSTALL_NPM -g \
     && docker-php-ext-install bcmath \
+    && pecl install xdebug \
+    && docker-php-ext-enable xdebug \
     && mkdir /root/.ssh \
     && touch /root/.ssh/known_hosts \
     && ssh-keyscan bitbucket.org >> /root/.ssh/known_hosts \


### PR DESCRIPTION
Added PHP XDebug extensions in PHP 5.6 & 7.0.

**Note**: XDebug is not yet available for PHP 7.1.0 (RC)
Everything will work as normal, except for PHPUnit not delivering code coverage.